### PR TITLE
Performance improvements and ASCII STL fix

### DIFF
--- a/javascripts/thingiloader.js
+++ b/javascripts/thingiloader.js
@@ -122,8 +122,8 @@ Thingiloader = function(event) {
     // console.log(STLString);
 
     // strip out extraneous stuff
+    STLString = STLString.replace(/^solid\s[^\n]*/, "");
     STLString = STLString.replace(/\n/g, " ");
-    STLString = STLString.replace(/solid\s(\w+)?/, "");
     STLString = STLString.replace(/facet normal /g,"");
     STLString = STLString.replace(/outer loop/g,"");  
     STLString = STLString.replace(/vertex /g,"");


### PR DESCRIPTION
I've improved the parsing algorithms, which are now linear in the input size (instead of exponential).  I host my models both on Thingiverse and on my own server, so you can compare the performance below.
- Before: http://www.thingiverse.com/thingiview:6702  (24 seconds on my machine)
- After: http://cliffle.com/thing/chess-set-i/preview/#pawn.stl  (1.5 seconds on my machine)
