### PR TITLE
Solved a rotation issue where we were losing the original interval PID

### DIFF
--- a/javascripts/thingiview.js
+++ b/javascripts/thingiview.js
@@ -393,11 +393,11 @@ Thingiview = function(containerId) {
 
   this.setRotation = function(rotate) {
     rotation = rotate;
-    
+    clearInterval(rotateTimer);
+
     if (rotate) {
       rotateTimer = setInterval(rotateLoop, 1000/60);
     } else {
-      clearInterval(rotateTimer);
       rotateTimer = null;
     }
 


### PR DESCRIPTION
The interval-timer for rotation was getting overwriten,
rather than cleared.  We were losing the handle to the
first rotation instance.

We solved this issue by unconditionally clearing the
interval, and then checking whether we are starting
or stopping.

Fixed #14
